### PR TITLE
multival/hexval/big endianness support

### DIFF
--- a/anon_pcap.py
+++ b/anon_pcap.py
@@ -18,12 +18,14 @@ def validate(vps):
 parser = argparse.ArgumentParser(description='Mini python script to replace specified value in PCAP(or any binary) file.')
 parser.add_argument('-s', '--srcpcap', help='Path to the raw PCAP file to be anonymized.', required=True)
 parser.add_argument('-d', '--dstpcap', help='Filename of the anonymized PCAP file.', default='anonymized.pcap')
-parser.add_argument('-v', '--values', help='A pair of values before/after anonymized.', metavar='VALUE', nargs=2, action='append')
+parser.add_argument('-v', '--strvals', help='A pair of values before/after anonymized in STRING format.', metavar='STRVAL', nargs=2, action='append')
+parser.add_argument('-x', '--hexvals', help='A pair of values before/after anonymized in HEX format.', metavar='HEXVAL', nargs=2, action='append')
 args = parser.parse_args()
 
 src_pcap  = args.srcpcap
 dst_pcap  = args.dstpcap
-val_pairs = args.values
+str_pairs = args.strvals
+hex_pairs = args.hexvals
 
 class PcapData():
     'Main class for PCAP to be handled.'
@@ -33,30 +35,55 @@ class PcapData():
         self.pcap_hex = self.bin2hex(self.pcap_bin)
 
     def file2bin(self, path):
+        ''' open pcap file as binary. '''
         bindata = open(path, 'rb').read()
         return bindata
 
     def bin2hex(self, bindata):
+        ''' convert binary into hexadecimal. '''
         hexdata = binascii.hexlify(bindata)
         return hexdata
 
     def str2hex(self, strdata):
-        h = binascii.hexlify(strdata)
-        return h
+        ''' convert string into hexadecimal. '''
+        hexdata = binascii.hexlify(strdata)
+        return hexdata
 
-    def replace_value(self, strargs):
+    def swap_str(self, strdata, fill):
+        ''' swap argument string by two characters(for the legacy protocols like SS7). '''
+        if len(strdata) % 2 == 1:
+            strdata = strdata + fill
+        swapped = ''.join(map(lambda x: x[::-1], [strdata[i: i+2] for i in range(0, len(strdata), 2)])) # python magic!
+        return swapped
+
+    def replace_strval(self, strargs):
+        ''' replace value with string-formatted argument(-v). '''
         for l in strargs:
-            self.pcap_mod_hex = self.pcap_hex.replace(self.str2hex(l[0]), self.str2hex(l[1]))
+            if self.str2hex(l[0]) not in self.pcap_hex:
+                self.pcap_hex = self.pcap_hex.replace(self.swap_str(l[0], 'f'), self.swap_str(l[1], l[1][-1]))
+                self.pcap_hex = self.pcap_hex.replace(self.swap_str(l[0], '0'), self.swap_str(l[1], l[1][-1]))
+                print 'Replaced "%s" as "%s"' % (l[0], l[1])
+            else:
+                self.pcap_hex = self.pcap_hex.replace(self.str2hex(l[0]), self.str2hex(l[1]))
+                print 'Replaced "%s" as "%s"' % (l[0], l[1])
+        return self.pcap_hex
+
+    def replace_hexval(self, hexargs):
+        ''' replace value with hex-formatted argument(-x). '''
+        for l in hexargs:
+            self.pcap_hex = self.pcap_hex.replace(l[0], l[1])
             print 'Replaced "%s" as "%s"' % (l[0], l[1])
-        return self.pcap_mod_hex
+        return self.pcap_hex
 
     def write_pcap(self, hexdata):
+        ''' write modified data as binary(pcap) file. '''
         self.dstfile.write(bytearray.fromhex(hexdata))
 
 def main():
-    validate(val_pairs)
+    validate(str_pairs)
     p = PcapData(src_pcap, dst_pcap)
-    r = p.replace_value(val_pairs)
+    r = p.replace_strval(str_pairs)
+    r = p.replace_hexval(hex_pairs)
     p.write_pcap(r)
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Added support for;  

1. replacing multiple arguments at a time.
2. replacing values with hexstring(no "0x" required), also OK with multiple args. This enables us replacing any values currently unsupported like MAC or IP.
3. replacing values with big endianness if the specified string is not found.  

### EXAMPLE
This will replace "org_val1" with "mod_val1", "org_val2" with "mod_val2",  and "deadbeef" with "beafdead".

```shell-session
# ./anon_pcap.py -s sig_PSI.pcap -d sig_PSI_anon3.pcap -v org_val1 mod_val1 -v org_val2 mod_val2 -x deadbeef beafdead
Replaced "org_val1" as "mod_val1"
Replaced "org_val2" as "mod_val2"
Replaced "deadbeef" as "beafdead"
```

### NOTES

Change#3 is to replace values like IMSI in GSM MAP packets. For instance,  the IMSI(E.212 number) "440980123456789" is actually shown as "44900821436587f9" when dumping hexstream.

| numbers | Human Readable | Actual Hex | Notes |
| --- | --- | --- | --- |
| IMSI | 440980123456789 | 44900821436587f9 | The last digit is filled with 'f' |
| MSISDN | 81901234567 | 1809214365f7 | The last digit is filled with 'f' |
| Global Title | 81901234567 | 1809214365f7 | The last digit is filled with '0' |

Quick implementation for this time is the following part, but still seeking better way to handle this kind of values.

```python
    def swap_str(self, strdata, fill):
        ''' swap argument string by two characters(for the legacy protocols like SS7). '''
        if len(strdata) % 2 == 1:
            strdata = strdata + fill
        swapped = ''.join(map(lambda x: x[::-1], [strdata[i: i+2] for i in range(0, len(strdata), 2)])) # python magic!
        return swapped
```

